### PR TITLE
Aanvullling van links naar DB definities van Adlib applicaties

### DIFF
--- a/AAPIs.md
+++ b/AAPIs.md
@@ -35,10 +35,16 @@ Commando's
     
 Adlib DB definities:
     [https://opac.geologie.ac.at/wwwopacx/adlibweb.xml]
+    
     [http://amdata.adlibsoft.com/adlibweb.xml]
+    
     [http://igem.adlibsoft.com/wwwopacx/adlibweb.xml]]
+    
     [http://service.aat-ned.nl/api/adlibweb.xml]
+    
     [http://fabrique.adlib.legermuseum.nl/api/adlibweb.xml]
+    
     [http://mmr.adlibhosting.com/madigopacx/adlibweb.xml]
+    
     [http://collectie.groningermuseum.nl/webapi/adlibweb.xml]
     

--- a/AAPIs.md
+++ b/AAPIs.md
@@ -33,19 +33,18 @@ Commando's
     database=[]&getmetadata
     database=[]&search=all&limit=X&startpriref=Y
     
-Adlib DB definities: </br>
+Adlib DB definities:
 
-    https://opac.geologie.ac.at/wwwopacx/adlibweb.xml </br>
+    [https://opac.geologie.ac.at/wwwopacx/adlibweb.xml|https://opac.geologie.ac.at/wwwopacx/adlibweb.xml]    
+    [http://amdata.adlibsoft.com/adlibweb.xml|http://amdata.adlibsoft.com/adlibweb.xml]
     
-    http://amdata.adlibsoft.com/adlibweb.xml </br>
+    http://igem.adlibsoft.com/wwwopacx/adlibweb.xml
     
-    http://igem.adlibsoft.com/wwwopacx/adlibweb.xml </br>
+    http://service.aat-ned.nl/api/adlibweb.xml
     
-    http://service.aat-ned.nl/api/adlibweb.xml </br>
+    http://fabrique.adlib.legermuseum.nl/api/adlibweb.xml
     
-    http://fabrique.adlib.legermuseum.nl/api/adlibweb.xml </br>
+    http://mmr.adlibhosting.com/madigopacx/adlibweb.xml
     
-    http://mmr.adlibhosting.com/madigopacx/adlibweb.xml </br>
-    
-    http://collectie.groningermuseum.nl/webapi/adlibweb.xml 
+    http://collectie.groningermuseum.nl/webapi/adlibweb.xml
     

--- a/AAPIs.md
+++ b/AAPIs.md
@@ -7,7 +7,7 @@ Google query:
 levert: 
 
     https://opac.geologie.ac.at/wwwopacx/wwwopac.ashx?  | Geologische Bundesanstalt Oostenrijk
-
+    
     http://amdata.adlibsoft.com/wwwopac.ashx? | Amsterdam Museum
 
     http://adlib.imf.org/digital_assets/wwwopac.ashx? | IMF
@@ -18,9 +18,9 @@ levert:
 
     http://adlib.zuiderzeemuseum.nl/api2/wwwopac.ashx? | Zuiderzeemuseum
 
-    http://service.aat-ned.nl/api/wwwopac.ashx  | AAT service RKD
+    http://service.aat-ned.nl/api/wwwopac.ashx  | AAT service RKD |
 
-    http://fabrique.adlib.legermuseum.nl/api/wwwopac.ashx | Legermuseum
+    http://fabrique.adlib.legermuseum.nl/api/wwwopac.ashx | Legermuseum 
      
     http://mmr.adlibhosting.com/madigopacx/wwwopac.ashx | Maritiem Digitaal 
 
@@ -33,3 +33,11 @@ Commando's
     database=[]&getmetadata
     database=[]&search=all&limit=X&startpriref=Y
     
+Adlib DB definities:
+    https://opac.geologie.ac.at/wwwopacx/adlibweb.xml
+    http://amdata.adlibsoft.com/adlibweb.xml
+    http://igem.adlibsoft.com/wwwopacx/adlibweb.xml
+    http://service.aat-ned.nl/api/adlibweb.xml
+    http://fabrique.adlib.legermuseum.nl/api/adlibweb.xml
+    http://mmr.adlibhosting.com/madigopacx/adlibweb.xml
+    http://collectie.groningermuseum.nl/webapi/adlibweb.xml

--- a/AAPIs.md
+++ b/AAPIs.md
@@ -34,18 +34,11 @@ Commando's
     database=[]&search=all&limit=X&startpriref=Y
     
 Adlib DB definities:
-
     [https://opac.geologie.ac.at/wwwopacx/adlibweb.xml]
-    
     [http://amdata.adlibsoft.com/adlibweb.xml]
-    
     [http://igem.adlibsoft.com/wwwopacx/adlibweb.xml]]
-    
     [http://service.aat-ned.nl/api/adlibweb.xml]
-    
     [http://fabrique.adlib.legermuseum.nl/api/adlibweb.xml]
-    
     [http://mmr.adlibhosting.com/madigopacx/adlibweb.xml]
-    
     [http://collectie.groningermuseum.nl/webapi/adlibweb.xml]
     

--- a/AAPIs.md
+++ b/AAPIs.md
@@ -35,8 +35,9 @@ Commando's
     
 Adlib DB definities:
 
-    [https://opac.geologie.ac.at/wwwopacx/adlibweb.xml|https://opac.geologie.ac.at/wwwopacx/adlibweb.xml]    
-    [http://amdata.adlibsoft.com/adlibweb.xml|http://amdata.adlibsoft.com/adlibweb.xml]
+    https://opac.geologie.ac.at/wwwopacx/adlibweb.xml
+    
+    http://amdata.adlibsoft.com/adlibweb.xml
     
     http://igem.adlibsoft.com/wwwopacx/adlibweb.xml
     

--- a/AAPIs.md
+++ b/AAPIs.md
@@ -34,17 +34,18 @@ Commando's
     database=[]&search=all&limit=X&startpriref=Y
     
 Adlib DB definities:
-    [https://opac.geologie.ac.at/wwwopacx/adlibweb.xml]
+
+    <https://opac.geologie.ac.at/wwwopacx/adlibweb.xml>
     
-    [http://amdata.adlibsoft.com/adlibweb.xml]
+    <http://amdata.adlibsoft.com/adlibweb.xml>
     
-    [http://igem.adlibsoft.com/wwwopacx/adlibweb.xml]]
+    <http://igem.adlibsoft.com/wwwopacx/adlibweb.xml>
     
-    [http://service.aat-ned.nl/api/adlibweb.xml]
+    <http://service.aat-ned.nl/api/adlibweb.xml>
     
-    [http://fabrique.adlib.legermuseum.nl/api/adlibweb.xml]
+    <http://fabrique.adlib.legermuseum.nl/api/adlibweb.xml>
     
-    [http://mmr.adlibhosting.com/madigopacx/adlibweb.xml]
+    <http://mmr.adlibhosting.com/madigopacx/adlibweb.xml>
     
-    [http://collectie.groningermuseum.nl/webapi/adlibweb.xml]
+    <http://collectie.groningermuseum.nl/webapi/adlibweb.xml>
     

--- a/AAPIs.md
+++ b/AAPIs.md
@@ -35,17 +35,17 @@ Commando's
     
 Adlib DB definities:
 
-    https://opac.geologie.ac.at/wwwopacx/adlibweb.xml
+    [https://opac.geologie.ac.at/wwwopacx/adlibweb.xml]
     
-    http://amdata.adlibsoft.com/adlibweb.xml
+    [http://amdata.adlibsoft.com/adlibweb.xml]
     
-    http://igem.adlibsoft.com/wwwopacx/adlibweb.xml
+    [http://igem.adlibsoft.com/wwwopacx/adlibweb.xml]]
     
-    http://service.aat-ned.nl/api/adlibweb.xml
+    [http://service.aat-ned.nl/api/adlibweb.xml]
     
-    http://fabrique.adlib.legermuseum.nl/api/adlibweb.xml
+    [http://fabrique.adlib.legermuseum.nl/api/adlibweb.xml]
     
-    http://mmr.adlibhosting.com/madigopacx/adlibweb.xml
+    [http://mmr.adlibhosting.com/madigopacx/adlibweb.xml]
     
-    http://collectie.groningermuseum.nl/webapi/adlibweb.xml
+    [http://collectie.groningermuseum.nl/webapi/adlibweb.xml]
     

--- a/AAPIs.md
+++ b/AAPIs.md
@@ -34,10 +34,18 @@ Commando's
     database=[]&search=all&limit=X&startpriref=Y
     
 Adlib DB definities:
+
     https://opac.geologie.ac.at/wwwopacx/adlibweb.xml
+    
     http://amdata.adlibsoft.com/adlibweb.xml
+    
     http://igem.adlibsoft.com/wwwopacx/adlibweb.xml
+    
     http://service.aat-ned.nl/api/adlibweb.xml
+    
     http://fabrique.adlib.legermuseum.nl/api/adlibweb.xml
+    
     http://mmr.adlibhosting.com/madigopacx/adlibweb.xml
+    
     http://collectie.groningermuseum.nl/webapi/adlibweb.xml
+    

--- a/AAPIs.md
+++ b/AAPIs.md
@@ -33,19 +33,19 @@ Commando's
     database=[]&getmetadata
     database=[]&search=all&limit=X&startpriref=Y
     
-Adlib DB definities:
+Adlib DB definities: </br>
 
-    <https://opac.geologie.ac.at/wwwopacx/adlibweb.xml>
+    https://opac.geologie.ac.at/wwwopacx/adlibweb.xml </br>
     
-    <http://amdata.adlibsoft.com/adlibweb.xml>
+    http://amdata.adlibsoft.com/adlibweb.xml </br>
     
-    <http://igem.adlibsoft.com/wwwopacx/adlibweb.xml>
+    http://igem.adlibsoft.com/wwwopacx/adlibweb.xml </br>
     
-    <http://service.aat-ned.nl/api/adlibweb.xml>
+    http://service.aat-ned.nl/api/adlibweb.xml </br>
     
-    <http://fabrique.adlib.legermuseum.nl/api/adlibweb.xml>
+    http://fabrique.adlib.legermuseum.nl/api/adlibweb.xml </br>
     
-    <http://mmr.adlibhosting.com/madigopacx/adlibweb.xml>
+    http://mmr.adlibhosting.com/madigopacx/adlibweb.xml </br>
     
-    <http://collectie.groningermuseum.nl/webapi/adlibweb.xml>
+    http://collectie.groningermuseum.nl/webapi/adlibweb.xml 
     

--- a/stylesheets/schema.xslt
+++ b/stylesheets/schema.xslt
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE rdf:RDF [
+<!ENTITY skos "http://www.w3.org/2004/02/skos/core#" >
+<!ENTITY schema "http://schema.org/" >
+]>
+
+<xsl:stylesheet version="1.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:dc="http://purl.org/dc/elements/1.1/"
+    xmlns:dct="http://purl.org/dc/terms/">
+<xsl:output method="xml" encoding="UTF-8" indent="yes"/>
+
+<xsl:template match="recordList">
+    <rdf:RDF>
+        <xsl:apply-templates select="record"/>        
+    </rdf:RDF>
+</xsl:template>
+
+
+
+
+
+
+
+</xsl:stylesheet>


### PR DESCRIPTION
Lijstje met links naar adlibweb.xml van geïmplementeerde systemen toegevoegd. Tevens een lege xslt voor conversie naar schema.org toegevoegd.